### PR TITLE
Check package.json for 'less' property

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
                 pathname = filepathWithLess
             } else if (fs.existsSync(pkginfo)) {
                 var info = JSON.parse(fs.readFileSync(pkginfo))
-                pathname = path.join(filepath, info.style || "index.less")
+                pathname = path.join(filepath, info.less || info.style || "index.less")
             } else if (fs.existsSync(indexFile)) {
                 pathname = indexFile
             }


### PR DESCRIPTION
In order to allow for packages that have both less and css in them (like twitter-bootstrap), I thought it would be a good idea to default to checking a `less` property on package.json before checking for a style property.

This would allow module authors to distribute both a compiled css file and a less file, and have it work with `npm-css`, `rework-npm`, and `npm-less`.
