### PR TITLE
Add support for per-file preprocessing

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,6 +174,6 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
 
 module.exports = function (opts) {
     var p = new Parser(opts)
-    Parser.preprocess = opts.preprocess || function (path, src) { return src }
+    Parser.preprocess = opts.preprocess
     return p
 }

--- a/index.js
+++ b/index.js
@@ -47,6 +47,9 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
         newFileInfo.currentDirectory = pathname.replace(/[^\\\/]*$/, "")
         newFileInfo.filename = pathname
 
+        // avoid preprocessing the same file more than once
+        if (!env.contents[pathname]) data = Parser.preprocess(pathname, data)
+
         // Updating top importing parser content cache.
         env.contents[pathname] = data
         env.currentFileInfo = newFileInfo
@@ -169,4 +172,8 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
     }
 }
 
-module.exports = Parser
+module.exports = function (opts) {
+    var p = new Parser(opts)
+    Parser.preprocess = opts.preprocess || function (path, src) { return src }
+    return p
+}

--- a/less.js
+++ b/less.js
@@ -5,10 +5,11 @@ var Parser = require("./index")
 
 module.exports = less
 
-function less(location, callback) {
+function less(location, callback, preprocess) {
     var parser = new Parser({
         paths: [path.dirname(location)],
-        filename: path.basename(location)
+        filename: path.basename(location),
+        preprocess: preprocess
     })
 
     fs.readFile(location, function (err, file) {

--- a/less.js
+++ b/less.js
@@ -5,12 +5,16 @@ var Parser = require("./index")
 
 module.exports = less
 
-function less(location, callback, preprocess) {
-    var options = {
-        paths: [path.dirname(location)],
-        filename: path.basename(location),
-        preprocess: preprocess || passThrough
+function less(location, options, callback) {
+    if (typeof options === 'function') {
+        callback = options
+        options = {}
     }
+
+    options.paths = options.paths || [path.dirname(location)]
+    options.filename = options.filename || path.basename(location)
+    options.preprocess = options.preprocess || passThrough
+
     var parser = new Parser(options)
 
     fs.readFile(location, {encoding: "utf8"}, function (err, src) {

--- a/less.js
+++ b/less.js
@@ -6,17 +6,23 @@ var Parser = require("./index")
 module.exports = less
 
 function less(location, callback, preprocess) {
-    var parser = new Parser({
+    var options = {
         paths: [path.dirname(location)],
         filename: path.basename(location),
-        preprocess: preprocess
-    })
+        preprocess: preprocess || passThrough
+    }
+    var parser = new Parser(options)
 
-    fs.readFile(location, function (err, file) {
+    fs.readFile(location, {encoding: "utf8"}, function (err, src) {
         if (err) {
             return callback(err)
         }
 
-        parser.parse(String(file), callback)
+        src = options.preprocess(location, src)
+        parser.parse(src, callback)
     })
+}
+
+function passThrough (file, src) {
+    return src
 }


### PR DESCRIPTION
PR for #3 for initial review

I made the preprocess function the final argument, which avoids breaking the API, but if you'd rather keep the callback as the last arg I can change that. I also couldn't get a "this" ref, so I just stuck it on the `Parser` object directly. The only other difference from what you suggested is that the path is passed into the function as the first arg. We need that info for our purposes, and it is reminiscent of a Browserify transform.

Thoughts?
