### PR TITLE
always check for files before trying to import a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,25 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
         var folder = env.paths[0]
         var targetFile = file.replace(/\.less$/, "")
 
-        if (targetFile[0] !== ".") {
+        // Check for files first
+        var filepath = path.join(folder, targetFile)
+        var filepathWithLess = filepath + ".less"
+        var pkginfo = path.join(filepath, "package.json")
+        var indexFile = path.join(filepath, "index.less")
+
+        if (fs.existsSync(filepath) && fs.statSync(filepath).isFile()) {
+            pathname = filepath
+        } else if (fs.existsSync(filepathWithLess)) {
+            pathname = filepathWithLess
+        } else if (fs.existsSync(pkginfo)) {
+            var info = JSON.parse(fs.readFileSync(pkginfo))
+            pathname = path.join(filepath, info.less || info.style || "index.less")
+        } else if (fs.existsSync(indexFile)) {
+            pathname = indexFile
+        }
+
+        // If no files were found, check for modules
+        if (!pathname && targetFile[0] !== ".") {
             var filePath
 
             try {
@@ -134,22 +152,6 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
             }
 
             pathname = filePath
-        } else {
-            var filepath = path.join(folder, targetFile)
-            var filepathWithLess = filepath + ".less"
-            var pkginfo = path.join(filepath, "package.json")
-            var indexFile = path.join(filepath, "index.less")
-
-            if (fs.existsSync(filepath) && fs.statSync(filepath).isFile()) {
-                pathname = filepath
-            } else if (fs.existsSync(filepathWithLess)) {
-                pathname = filepathWithLess
-            } else if (fs.existsSync(pkginfo)) {
-                var info = JSON.parse(fs.readFileSync(pkginfo))
-                pathname = path.join(filepath, info.less || info.style || "index.less")
-            } else if (fs.existsSync(indexFile)) {
-                pathname = indexFile
-            }
         }
 
         if (!pathname) {


### PR DESCRIPTION
Hi there, this allows to import bootstrap's less files directly like this:

```
@import 'bootstrap/less/bootstrap.less';
```

Without the patch it fails to find [these](https://github.com/twbs/bootstrap/blob/master/less/mixins.less).
