### PR TITLE
fix nested directory imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ Parser.importer = function (file, currentFileInfo, callback, env) {
             }
         }
 
-        var folder = env.paths[0]
+        var folder = paths[0] || env.paths[0]
         var targetFile = file.replace(/\.less$/, "")
 
         // Check for files first


### PR DESCRIPTION
This fixes a problem where the `index.less` file associated to an
`@import './directory'` statement couldn't be resolved if you had more
than one level of nested directories, like this:

```
.
├── index.less
└── moduleA
    ├── index.less
    └── moduleB
        ├── index.less
        └── moduleC
            └── index.less

// index.less
@import './moduleA';

// moduleA/index.less
import './moduleB';

// moduleA/moduleB/index.less
import './moduleC';
```
